### PR TITLE
Jaewon

### DIFF
--- a/src/components/GetBlogAllComponent.tsx
+++ b/src/components/GetBlogAllComponent.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState,useCallback } from "react";
 import { useAppDispatch } from "../hooks";
 import { useSelector } from "react-redux";
 import { RootState } from "../store/store";
 import { getBlogAll } from "../slices/blogSlice";
+import { searchBlog } from "../slices/blogSlice";
 import search from "../img/Search.png";
 import registerImg from "../img/register.png";
 import arrowLeft from "../img/arrowLeft.png";
@@ -109,13 +110,39 @@ export default function GetBlogAllComponent() {
     );
   });
 
+  const [keywords,setKeywords] = React.useState<searchBlogType>({
+    nickname: userNickname,
+    keyword: ""
+  })
+  const searchBlogs = (event: React.FormEvent<HTMLInputElement>) => {
+    // 변화한 값 받아서 setKeywords 호출
+    setKeywords({
+        nickname: userNickname,
+        keyword: event.currentTarget.value
+    })
+    console.log(event.currentTarget.value);
+    console.log(keywords);
+  };
+
+  const onSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        console.log(keywords);
+        dispatch(
+            searchBlog(keywords)
+        ).then((res)=>(setPosts(res.payload.data)));
+    },[dispatch,keywords]
+  );
+
   return (
     <GetBlogAllTable>
       <GetBlogAllTr>
         <GetBlogAllHeader>
           <div>
-            <SearchBlogInput type="text"></SearchBlogInput>
-            <SearchBlogImg src={search}></SearchBlogImg>
+            <form onSubmit={onSubmit}>
+                <SearchBlogInput type="text" onChange={searchBlogs} ></SearchBlogInput>
+                <SearchBlogImg src={search}></SearchBlogImg>
+            </form>
           </div>
           <div></div>
           <div>

--- a/src/components/GetBlogAllComponent.tsx
+++ b/src/components/GetBlogAllComponent.tsx
@@ -35,6 +35,9 @@ interface Posts {
 }
 
 export default function GetBlogAllComponent() {
+    const {user} = useSelector(
+        (state:RootState) => state.user
+    );
   const { blogs, inquireBlogDone } = useSelector(
     (state: RootState) => state.blog
   );
@@ -87,7 +90,14 @@ export default function GetBlogAllComponent() {
     navigate(`/blog/:${Number(blogInput.current?.getElementsByTagName("tr")[0].id)}`);
   }
 const registerBlogClick =() => {
-    navigate("/makeBlog")
+    console.log(userNickname);
+    console.log(user.nickname);
+    if(userNickname===(user.nickname)){
+        navigate("/makeBlog")
+    }else{
+        alert("본인 블로그에서만 글작성이 가능합니다!")
+    }
+    
 }
 
   const postLists: JSX.Element[] = posts.map((post) => {

--- a/src/components/GetBlogAllComponent.tsx
+++ b/src/components/GetBlogAllComponent.tsx
@@ -24,6 +24,7 @@ import {
   GetBlogAllBox,
   GetBlogNextImg,
 } from "./styled";
+import { useNavigate } from "react-router-dom";
 interface Posts {
   blogId: number;
   title: string;
@@ -36,6 +37,7 @@ export default function GetBlogAllComponent() {
   const { blogs, inquireBlogDone } = useSelector(
     (state: RootState) => state.blog
   );
+  const navigate = useNavigate();
 
   const dispatch = useAppDispatch();
   const [posts, setPosts] = React.useState<Posts[]>([]);
@@ -75,6 +77,9 @@ export default function GetBlogAllComponent() {
     }
     
   };
+//   const blogClick = () => {
+//     console.log(post.postId)
+//   }
 
   const postLists: JSX.Element[] = posts.map((post) => {
     return (

--- a/src/components/GetBlogAllComponent.tsx
+++ b/src/components/GetBlogAllComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState,useCallback } from "react";
+import React, { useEffect, useState,useCallback, useRef } from "react";
 import { useAppDispatch } from "../hooks";
 import { useSelector } from "react-redux";
 import { RootState } from "../store/store";
@@ -81,20 +81,22 @@ export default function GetBlogAllComponent() {
     }
     
   };
-//   const blogClick = () => {
-//     console.log(post.postId)
-//   }
+  const blogInput = useRef<HTMLTableRowElement>(null);
+  const blogClick = () => {
+    console.log(Number(blogInput.current?.getElementsByTagName("tr")[0].id)); //선택된 블로그 아이디 추출;
+    navigate(`/blog/:${Number(blogInput.current?.getElementsByTagName("tr")[0].id)}`);
+  }
 const registerBlogClick =() => {
     navigate("/makeBlog")
 }
 
   const postLists: JSX.Element[] = posts.map((post) => {
     return (
-      <GetBlogAllTr>
-        <td>
-          <GetBlogAllBox>
-            <table>
-              <tr>
+      <GetBlogAllTr  ref={blogInput} >
+        <td >
+          <GetBlogAllBox onClick={blogClick}>
+            <table >
+              <tr id={post.blogId.toString()}>
                 <GetBlogAllHeader>
                   <GetBlogAllTitle>{post.title}</GetBlogAllTitle>
                   <div></div>

--- a/src/components/GetBlogAllComponent.tsx
+++ b/src/components/GetBlogAllComponent.tsx
@@ -39,9 +39,9 @@ export default function GetBlogAllComponent() {
     (state: RootState) => state.blog
   );
   const navigate = useNavigate();
-  const userNickname = document.location.href.split("/")[5];
-//   console.log(document.location.href);
-//   console.log(userNickname);
+  const userNickname = document.location.href.split("/:")[1];
+  console.log(document.location.href);
+  console.log(userNickname);
 
   const dispatch = useAppDispatch();
   const [posts, setPosts] = React.useState<Posts[]>([]);
@@ -84,6 +84,9 @@ export default function GetBlogAllComponent() {
 //   const blogClick = () => {
 //     console.log(post.postId)
 //   }
+const registerBlogClick =() => {
+    navigate("/makeBlog")
+}
 
   const postLists: JSX.Element[] = posts.map((post) => {
     return (
@@ -146,7 +149,7 @@ export default function GetBlogAllComponent() {
           </div>
           <div></div>
           <div>
-            <PostBlogBtn>
+            <PostBlogBtn onClick={registerBlogClick}>
               <PostBlogImg src={registerImg}></PostBlogImg>
               글쓰기
             </PostBlogBtn>

--- a/src/components/GetBlogAllComponent.tsx
+++ b/src/components/GetBlogAllComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState,useCallback, useRef } from "react";
+import React, { useEffect, useState, useCallback, useRef } from "react";
 import { useAppDispatch } from "../hooks";
 import { useSelector } from "react-redux";
 import { RootState } from "../store/store";
@@ -35,9 +35,7 @@ interface Posts {
 }
 
 export default function GetBlogAllComponent() {
-    const {user} = useSelector(
-        (state:RootState) => state.user
-    );
+  const { user } = useSelector((state: RootState) => state.user);
   const { blogs, inquireBlogDone } = useSelector(
     (state: RootState) => state.blog
   );
@@ -71,41 +69,41 @@ export default function GetBlogAllComponent() {
   };
 
   const GetBlogPlus = () => {
-    console.log((blogs.data.length)%5);
+    console.log(blogs.data.length % 5);
     getBlogsData.pageNum = getBlogsData.pageNum + 1;
-    if((getBlogsData.pageNum) >((blogs.data.length)%5)){
-        getBlogsData.pageNum = getBlogsData.pageNum - 1;
-        alert("더이상 보여질 내용이 없습니다!")
-    }else{
-    console.log(getBlogsData);
-    dispatch(getBlogAll(getBlogsData)).then((res) =>
-      setPosts(res.payload.data.blogs)
-    );
+    if (getBlogsData.pageNum > blogs.data.length % 5) {
+      getBlogsData.pageNum = getBlogsData.pageNum - 1;
+      alert("더이상 보여질 내용이 없습니다!");
+    } else {
+      console.log(getBlogsData);
+      dispatch(getBlogAll(getBlogsData)).then((res) =>
+        setPosts(res.payload.data.blogs)
+      );
     }
-    
   };
   const blogInput = useRef<HTMLTableRowElement>(null);
   const blogClick = () => {
     console.log(Number(blogInput.current?.getElementsByTagName("tr")[0].id)); //선택된 블로그 아이디 추출;
-    navigate(`/blog/:${Number(blogInput.current?.getElementsByTagName("tr")[0].id)}`);
-  }
-const registerBlogClick =() => {
+    navigate(
+      `/blog/:${Number(blogInput.current?.getElementsByTagName("tr")[0].id)}`
+    );
+  };
+  const registerBlogClick = () => {
     console.log(userNickname);
     console.log(user.nickname);
-    if(userNickname===(user.nickname)){
-        navigate("/makeBlog")
-    }else{
-        alert("본인 블로그에서만 글작성이 가능합니다!")
+    if (userNickname === user.nickname) {
+      navigate("/makeBlog");
+    } else {
+      alert("본인 블로그에서만 글작성이 가능합니다!");
     }
-    
-}
+  };
 
   const postLists: JSX.Element[] = posts.map((post) => {
     return (
-      <GetBlogAllTr  ref={blogInput} >
-        <td >
+      <GetBlogAllTr ref={blogInput}>
+        <td>
           <GetBlogAllBox onClick={blogClick}>
-            <table >
+            <table>
               <tr id={post.blogId.toString()}>
                 <GetBlogAllHeader>
                   <GetBlogAllTitle>{post.title}</GetBlogAllTitle>
@@ -125,28 +123,27 @@ const registerBlogClick =() => {
     );
   });
 
-  const [keywords,setKeywords] = React.useState<searchBlogType>({
+  const [keywords, setKeywords] = React.useState<searchBlogType>({
     nickname: userNickname,
-    keyword: ""
-  })
+    keyword: "",
+  });
   const searchBlogs = (event: React.FormEvent<HTMLInputElement>) => {
     // 변화한 값 받아서 setKeywords 호출
     setKeywords({
-        nickname: userNickname,
-        keyword: event.currentTarget.value
-    })
+      nickname: userNickname,
+      keyword: event.currentTarget.value,
+    });
     console.log(event.currentTarget.value);
     console.log(keywords);
   };
 
   const onSubmit = useCallback(
     (event: React.FormEvent<HTMLFormElement>) => {
-        event.preventDefault();
-        console.log(keywords);
-        dispatch(
-            searchBlog(keywords)
-        ).then((res)=>(setPosts(res.payload.data)));
-    },[dispatch,keywords]
+      event.preventDefault();
+      console.log(keywords);
+      dispatch(searchBlog(keywords)).then((res) => setPosts(res.payload.data));
+    },
+    [dispatch, keywords]
   );
 
   return (
@@ -155,8 +152,11 @@ const registerBlogClick =() => {
         <GetBlogAllHeader>
           <div>
             <form onSubmit={onSubmit}>
-                <SearchBlogInput type="text" onChange={searchBlogs} ></SearchBlogInput>
-                <SearchBlogImg src={search}></SearchBlogImg>
+              <SearchBlogInput
+                type="text"
+                onChange={searchBlogs}
+              ></SearchBlogInput>
+              <SearchBlogImg src={search}></SearchBlogImg>
             </form>
           </div>
           <div></div>

--- a/src/components/GetBlogAllComponent.tsx
+++ b/src/components/GetBlogAllComponent.tsx
@@ -38,7 +38,9 @@ export default function GetBlogAllComponent() {
     (state: RootState) => state.blog
   );
   const navigate = useNavigate();
-  const userNickname = document.location.href.split("/:")[1];
+  const userNickname = document.location.href.split("/")[5];
+//   console.log(document.location.href);
+//   console.log(userNickname);
 
   const dispatch = useAppDispatch();
   const [posts, setPosts] = React.useState<Posts[]>([]);

--- a/src/components/GetBlogAllComponent.tsx
+++ b/src/components/GetBlogAllComponent.tsx
@@ -38,11 +38,12 @@ export default function GetBlogAllComponent() {
     (state: RootState) => state.blog
   );
   const navigate = useNavigate();
+  const userNickname = document.location.href.split("/:")[1];
 
   const dispatch = useAppDispatch();
   const [posts, setPosts] = React.useState<Posts[]>([]);
   const [getBlogsData, setGetBlogsData] = React.useState<getBlogAllType>({
-    nickname: "Jaewon",
+    nickname: userNickname,
     pageNum: 0,
   });
 

--- a/src/components/GetBlogComponent.tsx
+++ b/src/components/GetBlogComponent.tsx
@@ -50,13 +50,11 @@ export default function GetBlogComponenet() {
   const deleteBlogClick = () => {
     console.log(post.blogUser);
     console.log(user.nickname);
-    if(blog.blogUser===user.nickname){
-        dispatch(deleteBlog(blogId)).then(()=> (
-            navigate(-1)
-        ))
-    }else{
-        alert("본인 블로그에서만 삭제가 가능합니다.")
-    }  
+    if (post.blogUser === user.nickname) {
+      dispatch(deleteBlog(blogId)).then(() => navigate(-1));
+    } else {
+      alert("본인 블로그에서만 삭제가 가능합니다.");
+    }
   };
 
   useEffect(() => {

--- a/src/components/GetBlogComponent.tsx
+++ b/src/components/GetBlogComponent.tsx
@@ -28,6 +28,7 @@ interface Post {
 }
 
 export default function GetBlogComponenet() {
+  const { user } = useSelector((state: RootState) => state.user);
   const { blog } = useSelector((state: RootState) => state.blog);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
@@ -46,14 +47,20 @@ export default function GetBlogComponenet() {
     blogUserImg: "test",
   });
 
-  const deleteBlogClick = () =>{
-    dispatch(deleteBlog(blogId)).then(()=> (
-        navigate(-1)
-    ))
-  }
+  const deleteBlogClick = () => {
+    console.log(post.blogUser);
+    console.log(user.nickname);
+    if(blog.blogUser===user.nickname){
+        dispatch(deleteBlog(blogId)).then(()=> (
+            navigate(-1)
+        ))
+    }else{
+        alert("본인 블로그에서만 삭제가 가능합니다.")
+    }  
+  };
 
   useEffect(() => {
-    dispatch(getBlog(blogId)).then((res)=>(setPost(res.payload.data)));
+    dispatch(getBlog(blogId)).then((res) => setPost(res.payload.data));
   }, []);
 
   return (
@@ -80,7 +87,7 @@ export default function GetBlogComponenet() {
         </GetBlogAllTr>
         <GetBlogAllTr>
           <GetBlogBtnTd>
-            <GetBlogBtn >수정하기</GetBlogBtn>
+            <GetBlogBtn>수정하기</GetBlogBtn>
             <GetBlogBtn onClick={deleteBlogClick}>삭제하기</GetBlogBtn>
           </GetBlogBtnTd>
         </GetBlogAllTr>

--- a/src/components/GetBlogComponent.tsx
+++ b/src/components/GetBlogComponent.tsx
@@ -15,7 +15,8 @@ import {
 import { useAppDispatch } from "../hooks";
 import { useSelector } from "react-redux";
 import { RootState } from "../store/store";
-import { getBlog } from "../slices/blogSlice";
+import { getBlog, deleteBlog } from "../slices/blogSlice";
+import { useNavigate } from "react-router-dom";
 
 interface Post {
   blogId: number;
@@ -28,8 +29,9 @@ interface Post {
 
 export default function GetBlogComponenet() {
   const { blog } = useSelector((state: RootState) => state.blog);
+  const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const blogIdNum = Number(document.location.href.split("/")[4]);
+  const blogIdNum = Number(document.location.href.split("/:")[1]);
   console.log(document.location.href.split("/")[4]);
   console.log(blogIdNum);
   const [blogId, setBlogId] = React.useState<getBlogDetailType>({
@@ -43,6 +45,12 @@ export default function GetBlogComponenet() {
     blogUser: "test",
     blogUserImg: "test",
   });
+
+  const deleteBlogClick = () =>{
+    dispatch(deleteBlog(blogId)).then(()=> (
+        navigate("/")
+    ))
+  }
 
   useEffect(() => {
     dispatch(getBlog(blogId)).then((res)=>(setPost(res.payload.data)));
@@ -72,8 +80,8 @@ export default function GetBlogComponenet() {
         </GetBlogAllTr>
         <GetBlogAllTr>
           <GetBlogBtnTd>
-            <GetBlogBtn>수정하기</GetBlogBtn>
-            <GetBlogBtn>삭제하기</GetBlogBtn>
+            <GetBlogBtn >수정하기</GetBlogBtn>
+            <GetBlogBtn onClick={deleteBlogClick}>삭제하기</GetBlogBtn>
           </GetBlogBtnTd>
         </GetBlogAllTr>
       </GetBlogAllTable>

--- a/src/components/GetBlogComponent.tsx
+++ b/src/components/GetBlogComponent.tsx
@@ -48,7 +48,7 @@ export default function GetBlogComponenet() {
 
   const deleteBlogClick = () =>{
     dispatch(deleteBlog(blogId)).then(()=> (
-        navigate("/")
+        navigate(-1)
     ))
   }
 

--- a/src/components/GetBlogComponent.tsx
+++ b/src/components/GetBlogComponent.tsx
@@ -29,7 +29,9 @@ interface Post {
 export default function GetBlogComponenet() {
   const { blog } = useSelector((state: RootState) => state.blog);
   const dispatch = useAppDispatch();
-  const blogIdNum = Number(document.location.href.split("/:")[1]);
+  const blogIdNum = Number(document.location.href.split("/")[4]);
+  console.log(document.location.href.split("/")[4]);
+  console.log(blogIdNum);
   const [blogId, setBlogId] = React.useState<getBlogDetailType>({
     blogId: blogIdNum,
   });

--- a/src/components/GetBlogComponent.tsx
+++ b/src/components/GetBlogComponent.tsx
@@ -29,8 +29,9 @@ interface Post {
 export default function GetBlogComponenet() {
   const { blog } = useSelector((state: RootState) => state.blog);
   const dispatch = useAppDispatch();
+  const blogIdNum = Number(document.location.href.split("/:")[1]);
   const [blogId, setBlogId] = React.useState<getBlogDetailType>({
-    blogId: 150,
+    blogId: blogIdNum,
   });
   const [post, setPost] = React.useState<Post>({
     blogId: 1,

--- a/src/components/GetBlogComponent.tsx
+++ b/src/components/GetBlogComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import testImg from "../img/testImg.png";
 import {
   GetBlogAllTable,
@@ -12,8 +12,13 @@ import {
   GetBlogBtn,
   GetBlogBtnTd,
 } from "./styled";
+import { useAppDispatch } from "../hooks";
+import { useSelector } from "react-redux";
+import { RootState } from "../store/store";
+import { getBlog } from "../slices/blogSlice";
 
 interface Post {
+  blogId: number;
   title: string;
   content: string;
   createdAt: string;
@@ -22,14 +27,23 @@ interface Post {
 }
 
 export default function GetBlogComponenet() {
-  const [post, setPost] = React.useState<Post>({
-    title: "게시글 제목입니다.",
-    content:
-      "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.  n an unknown printer took a galley of type and scrambled it to make a type specimen book. Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.  n an unknown printer took a galley of type and scrambled it to make a type specimen book. Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.  n an unknown printer took a galley of type and scrambled it to make a type specimen book. Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.  n an unknown printer took a galley of type and scrambled it to make a type specimen book. ",
-    createdAt: "2020.10.08",
-    blogUser: "Jaewon",
-    blogUserImg: testImg,
+  const { blog } = useSelector((state: RootState) => state.blog);
+  const dispatch = useAppDispatch();
+  const [blogId, setBlogId] = React.useState<getBlogDetailType>({
+    blogId: 150,
   });
+  const [post, setPost] = React.useState<Post>({
+    blogId: 1,
+    title: "test",
+    content: "test",
+    createdAt: "test",
+    blogUser: "test",
+    blogUserImg: "test",
+  });
+
+  useEffect(() => {
+    dispatch(getBlog(blogId)).then((res)=>(setPost(res.payload.data)));
+  }, []);
 
   return (
     <div>
@@ -61,6 +75,5 @@ export default function GetBlogComponenet() {
         </GetBlogAllTr>
       </GetBlogAllTable>
     </div>
-    
   );
 }

--- a/src/components/MakeBlogComponent.tsx
+++ b/src/components/MakeBlogComponent.tsx
@@ -69,7 +69,9 @@ export default function MakeBlogComponent() {
             title: title,
             content: editorValue,
           })
-        );
+        ).then(()=>(
+          navigate(-1)
+        ));
       }
     },
     [dispatch, title, editorValue]

--- a/src/dataTypes.d.ts
+++ b/src/dataTypes.d.ts
@@ -63,6 +63,10 @@ type searchBlogType = {
   nickname: string;
   keyword: string;
 };
+type deleteBlogType = {
+  blogId: number;
+}
+
 
 type portfolioProjectType = {
   title: string;

--- a/src/slices/blogSlice.tsx
+++ b/src/slices/blogSlice.tsx
@@ -80,6 +80,21 @@ export const getBlog = createAsyncThunk(
     }
   }
 )
+//블로그 검색
+export const searchBlog = createAsyncThunk(
+  "searchBlog",
+  async(data:searchBlogType,{rejectWithValue}) =>{
+    try {
+      const res = await axios.post(`/blogs/search?${data.nickname}&keyword=${data.keyword}`, data, {
+        // withCredentials: true,
+      });
+      console.log(res.data);
+      return res.data;
+    } catch (error: any) {
+      console.log(error);
+      return rejectWithValue(error.response.data); //내부 에러처리
+  }
+})
 const blogSlice = createSlice({
   name: "blog",
   initialState,
@@ -163,6 +178,33 @@ const blogSlice = createSlice({
       state.inquireBlogDone = false;
       state.inquireBlogError = action.payload;
     },
+    //searchBlog 로직
+    [searchBlog.pending.type]: (
+      state,
+      action: PayloadAction<object>
+    ) => {
+      state.searchBlogLoading = true;
+      state.searchBlogDone = false;
+      state.searchBlogError = null;
+    },
+    [searchBlog.fulfilled.type]: (
+      state,
+      action: PayloadAction<object>
+    ) => {
+      state.searchBlogLoading = false;
+      state.searchBlogDone = true;
+      state.searchBlogError = null;
+      state.blogs = action.payload;
+    },
+    [searchBlog.rejected.type]: (
+      state,
+      action: PayloadAction<object>
+    ) => {
+      state.searchBlogLoading = false;
+      state.searchBlogDone = false;
+      state.searchBlogError = action.payload;
+    },
+
   },
 });
 

--- a/src/slices/blogSlice.tsx
+++ b/src/slices/blogSlice.tsx
@@ -85,9 +85,7 @@ export const searchBlog = createAsyncThunk(
   "searchBlog",
   async(data:searchBlogType,{rejectWithValue}) =>{
     try {
-      const res = await axios.post(`/blogs/search?${data.nickname}&keyword=${data.keyword}`, data, {
-        // withCredentials: true,
-      });
+      const res = await axios.get(`/blogs/search?nickname=${data.nickname}&keyword=${data.keyword}`);
       console.log(res.data);
       return res.data;
     } catch (error: any) {

--- a/src/slices/blogSlice.tsx
+++ b/src/slices/blogSlice.tsx
@@ -66,6 +66,20 @@ export const getBlogAll = createAsyncThunk(
   }
 );
 
+//블로그 상세 조회
+export const getBlog = createAsyncThunk(
+  "getBlog",
+  async (data:getBlogDetailType, {rejectWithValue}) => {
+    try{
+      const res = await axios.get(`/blog/${data}`);
+      console.log(res.data);
+      return res.data;
+    }catch(error: any){
+      console.log(error);
+      return rejectWithValue(error.response.data);
+    }
+  }
+)
 const blogSlice = createSlice({
   name: "blog",
   initialState,
@@ -103,16 +117,16 @@ const blogSlice = createSlice({
       action: PayloadAction<object>
     ) => {
       state.inquireBlogsLoading = true;
-      state.inquireBlogDone = false;
-      state.inquireBlogError = null;
+      state.inquireBlogsDone = false;
+      state.inquireBlogsError = null;
     },
     [getBlogAll.fulfilled.type]: (
       state,
       action: PayloadAction<object>
     ) => {
       state.inquireBlogsLoading = false;
-      state.inquireBlogDone = true;
-      state.inquireBlogError = null;
+      state.inquireBlogsDone = true;
+      state.inquireBlogsError = null;
       state.blogs = action.payload;
     },
     [getBlogAll.rejected.type]: (
@@ -120,6 +134,32 @@ const blogSlice = createSlice({
       action: PayloadAction<object>
     ) => {
       state.inquireBlogsLoading = false;
+      state.inquireBlogsDone = false;
+      state.inquireBlogsError = action.payload;
+    },
+    //getBlog로직
+    [ getBlog.pending.type]: (
+      state,
+      action: PayloadAction<object>
+    ) => {
+      state.inquireBlogLoading = true;
+      state.inquireBlogDone = false;
+      state.inquireBlogError = null;
+    },
+    [getBlog.fulfilled.type]: (
+      state,
+      action: PayloadAction<object>
+    ) => {
+      state.inquireBlogLoading = false;
+      state.inquireBlogDone = true;
+      state.inquireBlogError = null;
+      state.blog = action.payload;
+    },
+    [getBlog.rejected.type]: (
+      state,
+      action: PayloadAction<object>
+    ) => {
+      state.inquireBlogLoading = false;
       state.inquireBlogDone = false;
       state.inquireBlogError = action.payload;
     },

--- a/src/slices/blogSlice.tsx
+++ b/src/slices/blogSlice.tsx
@@ -93,6 +93,23 @@ export const searchBlog = createAsyncThunk(
       return rejectWithValue(error.response.data); //내부 에러처리
   }
 })
+//블로그 삭제
+export const deleteBlog = createAsyncThunk(
+  "deleteBlog",
+  async(data:deleteBlogType,{rejectWithValue})=> {
+    try {
+      axios.defaults.headers.common["Authorization"] = "";
+      const JWTTOEKN = localStorage.getItem("jwtToken");
+      axios.defaults.headers.common["Authorization"] = `Bearer ${JWTTOEKN}`;
+      const res = await axios.delete(`/blog/${data.blogId}`)
+      console.log(res.data);
+      return res.data;
+    } catch (error: any) {
+      console.log(error);
+      return rejectWithValue(error.response.data); //내부 에러처리
+    }
+  }
+)
 const blogSlice = createSlice({
   name: "blog",
   initialState,
@@ -177,7 +194,7 @@ const blogSlice = createSlice({
       state.inquireBlogError = action.payload;
     },
     //searchBlog 로직
-    [searchBlog.pending.type]: (
+    [deleteBlog.pending.type]: (
       state,
       action: PayloadAction<object>
     ) => {
@@ -185,7 +202,7 @@ const blogSlice = createSlice({
       state.searchBlogDone = false;
       state.searchBlogError = null;
     },
-    [searchBlog.fulfilled.type]: (
+    [deleteBlog.fulfilled.type]: (
       state,
       action: PayloadAction<object>
     ) => {
@@ -194,13 +211,38 @@ const blogSlice = createSlice({
       state.searchBlogError = null;
       state.blogs = action.payload;
     },
-    [searchBlog.rejected.type]: (
+    [deleteBlog.rejected.type]: (
       state,
       action: PayloadAction<object>
     ) => {
       state.searchBlogLoading = false;
       state.searchBlogDone = false;
       state.searchBlogError = action.payload;
+    },
+    //deleteBlog 로직
+    [searchBlog.pending.type]: (
+      state,
+      action: PayloadAction<object>
+    ) => {
+      state.deleteBlogLoading = true;
+      state.deleteBlogDone = false;
+      state.deleteBlogError = null;
+    },
+    [searchBlog.fulfilled.type]: (
+      state,
+      action: PayloadAction<object>
+    ) => {
+      state.deleteBlogLoading = false;
+      state.deleteBlogDone = true;
+      state.deleteBlogError = null;
+    },
+    [searchBlog.rejected.type]: (
+      state,
+      action: PayloadAction<object>
+    ) => {
+      state.deleteBlogLoading = false;
+      state.deleteBlogDone = false;
+      state.deleteBlogError = action.payload;
     },
 
   },

--- a/src/slices/blogSlice.tsx
+++ b/src/slices/blogSlice.tsx
@@ -71,7 +71,7 @@ export const getBlog = createAsyncThunk(
   "getBlog",
   async (data:getBlogDetailType, {rejectWithValue}) => {
     try{
-      const res = await axios.get(`/blog/${data}`);
+      const res = await axios.get(`/blog/${data.blogId}`);
       console.log(res.data);
       return res.data;
     }catch(error: any){


### PR DESCRIPTION
블로그 쪽 API 연동
1. 현재 포트폴리오 이동해서 블로그 보여짐 
2. 블로그에서 블로그 작성 버튼 누르면 블로그 작성페이지로 넘어감(자신의 블로그가 아닐시 작성페이지로 넘어가지 않음)
3. 블로그에서 세부 블로그 클릭 시 세부 블로그 보여지는 페이지로 넘어감
4. 세부 블로그 페이지에서 삭제버튼 누를시 삭제 됨(자신의 블로그가 아닐 시 삭제되지 않음)

블로그 쪽 남은 기능들
1. 블로그 보여지는 화면(html태그가 포함된 문자열로 보임 ->  이부분 스타일링 필요)
2. 수정 기능
3. 검색기능(API만 수정되면 되는 부분이라 추후에 한번에 말씀드리고 수정하면 될듯)